### PR TITLE
Ad849x support

### DIFF
--- a/aprinter/printer/thermistor/PositiveLinearFormula.h
+++ b/aprinter/printer/thermistor/PositiveLinearFormula.h
@@ -29,10 +29,22 @@
 #include <aprinter/math/FloatTools.h>
 #include <aprinter/printer/Configuration.h>
 
+/*
+ * AD849x - K-Type thermocouple amplifier, eg. https://www.adafruit.com/product/1778
+ *     zero offset 1.25V, slope 5mV/K, ADC reference 3.3V
+ *         ZeroAdcValue = 1.25V/3.3V        = 0.379
+ *         AdcSlope     = (0.005V/K)/3.3V   = 1.515e-3 1/K
+ *
+ * MAX849x - K-Type thermocouple amplifier
+ *     zero offset 0V, slope 5mV/K, ADC reference 3.3V
+ *         ZeroAdcValue = 0
+ *         AdcSlope     = 1.515e-3 1/K
+ */
+
 namespace APrinter {
 
 template <typename Arg>
-class Ad849xFormula {
+class PositiveLinearFormula {
     using Context      = typename Arg::Context;
     using Config       = typename Arg::Config;
     using FpType       = typename Arg::FpType;
@@ -42,7 +54,8 @@ public:
     static bool const NegativeSlope = false;
     
     template <typename Temp>
-    static auto TempToAdc (Temp) -> decltype(Temp()/Config::e(Params::Slope::i()) + Config::e(Params::OffsetVoltage::i()));
+    static auto TempToAdc (Temp) -> decltype(Temp()*Config::e(Params::AdcSlope::i()) +
+                                    Config::e(Params::ZeroAdcValue::i()));
 
     static FpType adcToTemp (Context c, FpType adc)
     {
@@ -52,24 +65,24 @@ public:
         if (!(adc >= APRINTER_CFG(Config, CAdcMinTemp, c))) {
             return -INFINITY;
         }
-        return (adc - APRINTER_CFG(Config, COffsetVoltage, c)) * APRINTER_CFG(Config, CSlope, c);
+        return (adc - APRINTER_CFG(Config, CZeroAdcValue, c)) / APRINTER_CFG(Config, CAdcSlope, c);
     }
 
 private:
     using CAdcMinTemp = decltype(ExprCast<FpType>(TempToAdc(Config::e(Params::MinTemp::i()))));
     using CAdcMaxTemp = decltype(ExprCast<FpType>(TempToAdc(Config::e(Params::MaxTemp::i()))));
-    using COffsetVoltage = decltype(ExprCast<FpType>(Config::e(Params::OffsetVoltage::i())));
-    using CSlope = decltype(ExprCast<FpType>(Config::e(Params::Slope::i())));
+    using CZeroAdcValue = decltype(ExprCast<FpType>(Config::e(Params::ZeroAdcValue::i())));
+    using CAdcSlope = decltype(ExprCast<FpType>(Config::e(Params::AdcSlope::i())));
 
 public:
     struct Object {};
 
-    using ConfigExprs = MakeTypeList<CAdcMinTemp, CAdcMaxTemp, COffsetVoltage, CSlope>;
+    using ConfigExprs = MakeTypeList<CAdcMinTemp, CAdcMaxTemp, CZeroAdcValue, CAdcSlope>;
 };
 
-APRINTER_ALIAS_STRUCT_EXT(Ad849xFormulaService, (
-    APRINTER_AS_TYPE(OffsetVoltage),
-    APRINTER_AS_TYPE(Slope),
+APRINTER_ALIAS_STRUCT_EXT(PositiveLinearFormulaService, (
+    APRINTER_AS_TYPE(ZeroAdcValue),
+    APRINTER_AS_TYPE(AdcSlope),
     APRINTER_AS_TYPE(MinTemp),
     APRINTER_AS_TYPE(MaxTemp)
 ), (
@@ -79,8 +92,8 @@ APRINTER_ALIAS_STRUCT_EXT(Ad849xFormulaService, (
         APRINTER_AS_TYPE(Config),
         APRINTER_AS_TYPE(FpType)
     ), (
-        using Params = Ad849xFormulaService;
-        APRINTER_DEF_INSTANCE(Formula, Ad849xFormula)
+        using Params = PositiveLinearFormulaService;
+        APRINTER_DEF_INSTANCE(Formula, PositiveLinearFormula)
     ))
 ))
 

--- a/aprinter/printer/thermistor/PositiveLinearFormula.h
+++ b/aprinter/printer/thermistor/PositiveLinearFormula.h
@@ -28,6 +28,7 @@
 #include <aprinter/meta/ServiceUtils.h>
 #include <aprinter/math/FloatTools.h>
 #include <aprinter/printer/Configuration.h>
+#include <aprinter/base/ProgramMemory.h>
 
 /*
  * AD849x - K-Type thermocouple amplifier, eg. https://www.adafruit.com/product/1778
@@ -59,6 +60,11 @@ public:
 
     static FpType adcToTemp (Context c, FpType adc)
     {
+        // prevent thermal runaway
+        if (0 >= APRINTER_CFG(Config, CAdcSlope, c)) {
+            Context::Printer::print_pgm_string(c, AMBRO_PSTR("//Error:AdcSlope must be positive\n"));
+            return INFINITY;
+        }
         if (!(adc <= APRINTER_CFG(Config, CAdcMaxTemp, c))) {
             return INFINITY;
         }

--- a/config_system/generator/generate.py
+++ b/config_system/generator/generate.py
@@ -2076,12 +2076,12 @@ def generate(config_root_data, cfg_name, main_template):
                     gen.add_aprinter_include('printer/thermistor/InterpolationTableThermistor_tables.h')
                     return TemplateExpr('InterpolationTableThermistorService', ['InterpolationTableE3dPt100'])
 
-                @conversion_sel.option('Ad849xFormula')
+                @conversion_sel.option('PositiveLinearFormula')
                 def option(conversion_config):
-                    gen.add_aprinter_include('printer/thermistor/Ad849xFormula.h')
-                    return TemplateExpr('Ad849xFormulaService', [
-                        gen.add_float_config('{}HeaterTempOffsetVoltage'.format(name), conversion_config.get_float('OffsetVoltage')),
-                        gen.add_float_config('{}HeaterTempSlope'.format(name), conversion_config.get_float('Slope')),
+                    gen.add_aprinter_include('printer/thermistor/PositiveLinearFormula.h')
+                    return TemplateExpr('PositiveLinearFormulaService', [
+                        gen.add_float_config('{}HeaterTempZeroAdcValue'.format(name), conversion_config.get_float('ZeroAdcValue')),
+                        gen.add_float_config('{}HeaterTempAdcSlope'.format(name), conversion_config.get_float('AdcSlope')),
                         gen.add_float_config('{}HeaterTempMinTemp'.format(name), conversion_config.get_float('MinTemp')),
                         gen.add_float_config('{}HeaterTempMaxTemp'.format(name), conversion_config.get_float('MaxTemp')),
                     ])

--- a/config_system/generator/generate.py
+++ b/config_system/generator/generate.py
@@ -2075,7 +2075,17 @@ def generate(config_root_data, cfg_name, main_template):
                 def option(conversion_config):
                     gen.add_aprinter_include('printer/thermistor/InterpolationTableThermistor_tables.h')
                     return TemplateExpr('InterpolationTableThermistorService', ['InterpolationTableE3dPt100'])
-                
+
+                @conversion_sel.option('Ad849xFormula')
+                def option(conversion_config):
+                    gen.add_aprinter_include('printer/thermistor/Ad849xFormula.h')
+                    return TemplateExpr('Ad849xFormulaService', [
+                        gen.add_float_config('{}HeaterTempOffsetVoltage'.format(name), conversion_config.get_float('OffsetVoltage')),
+                        gen.add_float_config('{}HeaterTempSlope'.format(name), conversion_config.get_float('Slope')),
+                        gen.add_float_config('{}HeaterTempMinTemp'.format(name), conversion_config.get_float('MinTemp')),
+                        gen.add_float_config('{}HeaterTempMaxTemp'.format(name), conversion_config.get_float('MaxTemp')),
+                    ])
+
                 conversion = heater.do_selection('conversion', conversion_sel)
                 
                 for control in heater.enter_config('control'):


### PR DESCRIPTION
not working (yet), but compiles :)

Is there a way to get the scaling of the adc? It is important in this case as the output of these modules = temperature*5mV/K + 1.25V. Hardcoding to 3.3V seems a bit ugly (in case AREF isn't yet available) as it will not work for systems that use 5V for AREF.

Adding another parameter to the module would be somewhat a middle ground between the effort of adding it to each HAL and hardcoding.

BTW: I think that InterpolationTableE3dPt100 has the same issue. 